### PR TITLE
feat!: before send hooks 

### DIFF
--- a/x/tokenfactory/ante/before_send_hook.go
+++ b/x/tokenfactory/ante/before_send_hook.go
@@ -1,0 +1,61 @@
+package decorators
+
+import (
+	"fmt"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/strangelove-ventures/tokenfactory/x/tokenfactory/keeper"
+	tokenfactorytypes "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type MsgBeforeSendHook struct {
+	TokenFactoryKeeper keeper.Keeper
+}
+
+func NewMsgBeforeSendHook(k keeper.Keeper) MsgBeforeSendHook {
+	return MsgBeforeSendHook{
+		TokenFactoryKeeper: k,
+	}
+}
+
+func (mfd MsgBeforeSendHook) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	mfd.applyDenomHookIfApplicable(tx.GetMsgs())
+	return next(ctx, tx, simulate)
+}
+
+func (mfd MsgBeforeSendHook) applyDenomHookIfApplicable(msgs []sdk.Msg) {
+	for _, msg := range msgs {
+		// TODO: authz nested check here
+
+		if m, ok := msg.(*banktypes.MsgSend); ok {
+			mfd.performAction(m)
+		}
+	}
+}
+
+func (mfd MsgBeforeSendHook) performAction(msg *banktypes.MsgSend) {
+	sender := msg.FromAddress
+	recipient := msg.ToAddress
+	coins := msg.Amount
+
+	for _, coin := range coins {
+		coin := coin
+
+		// validate is a tokenfactory denom
+		_, _, err := tokenfactorytypes.DeconstructDenom(coin.Denom)
+		if err != nil {
+			continue
+		}
+
+		// This is a validate tokenfactory denom being sent, check if it is registered for hooks
+		fireEvent(sender, recipient, coin)
+	}
+}
+
+func fireEvent(sender, recipient string, coin sdk.Coin) error {
+	// Perform the SudoMsg execute if it is registered.
+	fmt.Printf("Fire event for %s -> %s: %s\n", sender, recipient, coin)
+	return nil
+}

--- a/x/tokenfactory/ante/before_send_test.go
+++ b/x/tokenfactory/ante/before_send_test.go
@@ -1,0 +1,57 @@
+package decorators_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/strangelove-ventures/tokenfactory/app"
+	"github.com/stretchr/testify/require"
+
+	ante "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/ante"
+)
+
+var (
+	EmptyAnte = func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		return ctx, nil
+	}
+)
+
+func TestBeforeSend(t *testing.T) {
+	// generate a private/public key pair and get the respective address
+	pk1 := ed25519.GenPrivKey().PubKey()
+	fromAddr := sdk.AccAddress(pk1.Address())
+
+	pk2 := ed25519.GenPrivKey().PubKey()
+	toAddr := sdk.AccAddress(pk2.Address())
+
+	// app, ctx := bindings.SetupCustomApp(t, addr1)
+	ctx, chain := app.Setup(t)
+
+	token, err := chain.TokenFactoryKeeper.CreateDenom(ctx, fromAddr.String(), "bitcoin")
+	require.NoError(t, err)
+
+	fmt.Println(token)
+
+	// Create change rate decorator
+	anteHandler := ante.NewMsgBeforeSendHook(chain.TokenFactoryKeeper)
+
+	bankSendMsg := banktypes.MsgSend{
+		FromAddress: fromAddr.String(),
+		ToAddress:   toAddr.String(),
+		Amount:      sdk.NewCoins(sdk.NewCoin(token, sdkmath.NewInt(100))),
+	}
+
+	if _, err := anteHandler.AnteHandle(ctx, NewMockTx(&bankSendMsg), false, EmptyAnte); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// change this to a hooks contract (on call increase, ref clock)
+	// reflect := instantiateReflectContract(t, ctx, app, actor)
+	// require.NotEmpty(t, reflect)
+
+}

--- a/x/tokenfactory/ante/mocks_test.go
+++ b/x/tokenfactory/ante/mocks_test.go
@@ -1,0 +1,28 @@
+package decorators_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	protov2 "google.golang.org/protobuf/proto"
+)
+
+type MockTx struct {
+	msgs []sdk.Msg
+}
+
+func NewMockTx(msgs ...sdk.Msg) MockTx {
+	return MockTx{
+		msgs: msgs,
+	}
+}
+
+func (tx MockTx) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx MockTx) GetMsgsV2() ([]protov2.Message, error) {
+	return nil, nil
+}
+
+func (tx MockTx) ValidateBasic() error {
+	return nil
+}


### PR DESCRIPTION
When a token is sent, allow a token admin to register cosmwasm execution to perform some other logic before it applies