### PR TITLE
fix: don't call SetAddressPrefixes() on init

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -26,7 +26,7 @@ var (
 )
 
 func init() {
-	SetAddressPrefixes()
+	// SetAddressPrefixes()
 	RegisterDenoms()
 }
 


### PR DESCRIPTION
calling in a test suite causes a config sealed error (spawn w/ ethos integration)