### PR TITLE
ci: coverage report and badges

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,3 +79,35 @@ jobs:
 
       - name: Run Test
         run: make ${{ matrix.test }}
+
+  coverage:
+    needs: build-docker
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions/checkout@v4
+
+     - uses: actions/setup-go@v4
+       with:
+         go-version: ${{ env.GO_VERSION }}
+
+     - name: Download Host Artifact
+       uses: actions/download-artifact@v3
+       with:
+         name: ${{ env.IMAGE_NAME }}
+         path: /tmp
+
+     - name: Load Docker Image
+       run: |
+         docker image load -i ${{ env.TAR_PATH }}
+         docker image ls -a
+
+     - name: Run coverage
+       run: make coverage
+
+     - name: Upload coverage to Codecov
+       uses: codecov/codecov-action@v4
+       with:
+         file: /tmp/tokenfactory-coverage/coverage-merged-filtered.out
+         token: ${{ secrets.CODECOV_TOKEN }}
+       env:
+         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Token Factory
 
+![GitHub commit check runs](https://img.shields.io/github/check-runs/strangelove-ventures/tokenfactory/main)
+![Codecov](https://img.shields.io/codecov/c/github/strangelove-ventures/tokenfactory)
+
 The `tokenfactory` module allows any account to create a new token with the name `factory/{creator address}/{subdenom}`. Because tokens are namespaced by creator address, this allows token minting to be permissionless, due to not needing to resolve name collisions. A single account can create multiple denoms, by providing a unique subdenom for each created denom. Once a denom is created, the original creator is given "admin" privileges over the asset. This allows them to:
 
 - Mint their denom to any account


### PR DESCRIPTION
This PR adds a coverage report to e2e testing and uploads it to codecov. This PR also adds build and coverage badges to README.

If not already done, please add the CodeCov token to this repo as described in https://docs.codecov.com/docs/github-2-getting-a-codecov-account-and-uploading-coverage#add-the-codecov-token-to-your-repo-or-your-org

@Reecepbcups
@beckettsean